### PR TITLE
setup.py: Exclude tests from runtime package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include requirements.in
 include test-requirements.in
+include README.md
+include LICENSE
+include tox.ini
 graft docs
+recursive-include test *.py

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Josef Podany",
     author_email="josef.podany@kiwi.com",
-    packages=find_packages(),
+    packages=find_packages(exclude=["test*"]),
     install_requires=install_requires,
     tests_require=tests_require,
     include_package_data=True,


### PR DESCRIPTION
Include tests in the sdist only, along with other
files needed to run the tests and do packaging.