### PR TITLE
fix(request_session): remove import attr

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
-known_third_party = attr,httpbin,pytest,requests,setuptools,simplejson,six
+known_third_party = httpbin,pytest,requests,setuptools,simplejson,six
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/request_session/request_session.py
+++ b/request_session/request_session.py
@@ -6,7 +6,6 @@ from collections import namedtuple
 from typing import List  # pylint: disable=unused-import
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
-import attr
 import requests
 import requests.adapters
 import simplejson as json


### PR DESCRIPTION
fix this issue when pytest is not installed:

```
  File "/usr/local/lib/python3.8/site-packages/request_session/__init__.py", line 4, in <module>
    from .request_session import RequestSession, Timeout
  File "/usr/local/lib/python3.8/site-packages/request_session/request_session.py", line 9, in <module>
    import attr
ModuleNotFoundError: No module named 'attr'
```