### PR TITLE
feat: remove retries from HTTPAdapter

### DIFF
--- a/request_session/request_session.py
+++ b/request_session/request_session.py
@@ -139,7 +139,7 @@ class RequestSession(object):
         self.session = requests.Session()
         self.session_instances.append(self.session)
 
-        adapter = requests.adapters.HTTPAdapter(max_retries=1)
+        adapter = requests.adapters.HTTPAdapter()
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
 


### PR DESCRIPTION
Retries are handled on a higher level in _process() method along with telemetry around them. Separate retries on HTTPAdapter are redundant and unexpected.